### PR TITLE
Merge `TestCompositeKnot` into `CompositeKnot`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 allprojects {
     group = "de.halfbit"
-    version = "1.1"
+    version = "1.2"
 
     repositories {
         mavenCentral()

--- a/knot/src/main/kotlin/de/halfbit/knot/CompositeKnot.kt
+++ b/knot/src/main/kotlin/de/halfbit/knot/CompositeKnot.kt
@@ -96,9 +96,9 @@ internal class DefaultCompositeKnot<State : Any>(
                         .also { it.action?.let { action -> actionSubject.onNext(action) } }
                         .state
                 }
+                .intercept(stateInterceptors)
                 .distinctUntilChanged()
                 .let { stream -> observeOn?.let { stream.observeOn(it) } ?: stream }
-                .intercept(stateInterceptors)
                 .subscribe(
                     { stateSubject.onNext(it) },
                     { stateSubject.onError(it) }

--- a/knot/src/main/kotlin/de/halfbit/knot/CompositeKnot.kt
+++ b/knot/src/main/kotlin/de/halfbit/knot/CompositeKnot.kt
@@ -23,7 +23,10 @@ import kotlin.reflect.KClass
  * Once all `Primes` are registered at a `CompositeKnot`, the knot can be finally composed using
  * [compose] function and start operating.
  */
-interface CompositeKnot<State : Any> : Store<State> {
+interface CompositeKnot<State : Any> : Knot<State, Any> {
+
+    /** Change emitter used for delivering changes to this knot. */
+    override val change: Consumer<Any>
 
     /** Registers a new `Prime` at this composite knot. */
     fun <Change : Any, Action : Any> registerPrime(block: PrimeBuilder<State, Change, Action>.() -> Unit)
@@ -32,10 +35,6 @@ interface CompositeKnot<State : Any> : Store<State> {
     fun compose()
 }
 
-/** A capable of emitting `Changes` interface for testing [CompositeKnot] and its `Primes`. */
-interface TestCompositeKnot<State : Any, Change : Any> :
-    CompositeKnot<State>, Knot<State, Change>
-
 internal class DefaultCompositeKnot<State : Any>(
     private val initialState: State,
     private val observeOn: Scheduler?,
@@ -43,7 +42,7 @@ internal class DefaultCompositeKnot<State : Any>(
     private val stateInterceptors: MutableList<Interceptor<State>>,
     private val changeInterceptors: MutableList<Interceptor<Any>>,
     private val actionInterceptors: MutableList<Interceptor<Any>>
-) : CompositeKnot<State>, TestCompositeKnot<State, Any> {
+) : CompositeKnot<State> {
 
     private val reducers = mutableMapOf<KClass<out Any>, Reducer<State, Any, Any>>()
     private val actionTransformers = mutableListOf<ActionTransformer<Any, Any>>()

--- a/knot/src/main/kotlin/de/halfbit/knot/CompositeKnotBuilder.kt
+++ b/knot/src/main/kotlin/de/halfbit/knot/CompositeKnotBuilder.kt
@@ -1,22 +1,12 @@
 package de.halfbit.knot
 
 import io.reactivex.Scheduler
-import org.jetbrains.annotations.TestOnly
 import kotlin.reflect.KClass
 
 /** Creates a [CompositeKnot]. */
 fun <State : Any> compositeKnot(
     block: CompositeKnotBuilder<State>.() -> Unit
 ): CompositeKnot<State> =
-    CompositeKnotBuilder<State>()
-        .also(block)
-        .build()
-
-/** Creates a [TestCompositeKnot]. To be used in tests only. */
-@TestOnly
-fun <State : Any> testCompositeKnot(
-    block: CompositeKnotBuilder<State>.() -> Unit
-): TestCompositeKnot<State, Any> =
     CompositeKnotBuilder<State>()
         .also(block)
         .build()

--- a/knot/src/main/kotlin/de/halfbit/knot/Knot.kt
+++ b/knot/src/main/kotlin/de/halfbit/knot/Knot.kt
@@ -143,9 +143,9 @@ internal class DefaultKnot<State : Any, Change : Any, Action : Any>(
                 .also { it.action?.let { action -> actionSubject.onNext(action) } }
                 .state
         }
+        .intercept(stateInterceptors)
         .distinctUntilChanged()
         .let { stream -> observeOn?.let { stream.observeOn(it) } ?: stream }
-        .intercept(stateInterceptors)
         .replay(1)
         .also { disposable.add(it.connect()) }
 

--- a/knot/src/test/kotlin/de/halfbit/knot/CompositeKnotTest.kt
+++ b/knot/src/test/kotlin/de/halfbit/knot/CompositeKnotTest.kt
@@ -74,7 +74,7 @@ class CompositeKnotTest {
 
     @Test(expected = IllegalStateException::class)
     fun `TestCompositeKnot fails emitting changes when knot is not composed`() {
-        val knot = testCompositeKnot<State> {
+        val knot = compositeKnot<State> {
             state { initial = State }
         }
         knot.change.accept(Unit)

--- a/knot/src/test/kotlin/de/halfbit/knot/PrimeTest.kt
+++ b/knot/src/test/kotlin/de/halfbit/knot/PrimeTest.kt
@@ -24,7 +24,7 @@ class PrimeTest {
 
     @Test
     fun `CompositeKnot emits IllegalStateException if reducer cannot be found`() {
-        val knot = testCompositeKnot<State> {
+        val knot = compositeKnot<State> {
             state { initial = State("empty") }
         }
 
@@ -37,7 +37,7 @@ class PrimeTest {
 
     @Test
     fun `CompositeKnot picks reducers by change type`() {
-        val knot = testCompositeKnot<State> {
+        val knot = compositeKnot<State> {
             state { initial = State("empty") }
         }
 
@@ -66,7 +66,7 @@ class PrimeTest {
         val changeA = PublishSubject.create<Unit>()
         val changeB = PublishSubject.create<Unit>()
 
-        val knot = testCompositeKnot<State> {
+        val knot = compositeKnot<State> {
             state { initial = State("empty") }
         }
 
@@ -96,7 +96,7 @@ class PrimeTest {
 
     @Test
     fun `CompositeKnot performs actions`() {
-        val knot = testCompositeKnot<State> {
+        val knot = compositeKnot<State> {
             state { initial = State("empty") }
         }
 
@@ -135,7 +135,7 @@ class PrimeTest {
             visited = true
             it.run()
         }
-        val knot = testCompositeKnot<State> {
+        val knot = compositeKnot<State> {
             state {
                 initial = State("empty")
             }
@@ -159,7 +159,7 @@ class PrimeTest {
     @Test
     fun `Disposed CompositeKnot ignores emitted changes`() {
 
-        val knot = testCompositeKnot<State> {
+        val knot = compositeKnot<State> {
             state { initial = State("empty") }
         }
         knot.registerPrime<Change, Action> {
@@ -182,7 +182,7 @@ class PrimeTest {
     @Test
     fun `Disposed CompositeKnot ignores emitted events`() {
 
-        val knot = testCompositeKnot<State> {
+        val knot = compositeKnot<State> {
             state { initial = State("empty") }
         }
 
@@ -212,7 +212,7 @@ class PrimeTest {
     @Test
     fun `Composed CompositeKnot subscribes event source`() {
 
-        val knot = testCompositeKnot<State> {
+        val knot = compositeKnot<State> {
             state { initial = State("empty") }
         }
 
@@ -235,7 +235,7 @@ class PrimeTest {
     @Test
     fun `Disposed CompositeKnot unsubscribes event source`() {
 
-        val knot = testCompositeKnot<State> {
+        val knot = compositeKnot<State> {
             state { initial = State("empty") }
         }
 
@@ -258,7 +258,7 @@ class PrimeTest {
 
     @Test
     fun `Reducer throws error on unexpected()`() {
-        val knot = testCompositeKnot<State> {
+        val knot = compositeKnot<State> {
             state { initial = State("empty") }
         }
 
@@ -278,7 +278,7 @@ class PrimeTest {
     fun `Prime actions { watchAll } receives Action`() {
         val watcher = PublishSubject.create<Action>()
         val observer = watcher.test()
-        val knot = testCompositeKnot<State> {
+        val knot = compositeKnot<State> {
             state { initial = State("empty") }
         }
         knot.registerPrime<Change, Action> {
@@ -300,7 +300,7 @@ class PrimeTest {
     fun `Prime actions { watch } receives Action`() {
         val watcher = PublishSubject.create<Action>()
         val observer = watcher.test()
-        val knot = testCompositeKnot<State> {
+        val knot = compositeKnot<State> {
             state { initial = State("empty") }
         }
         knot.registerPrime<Change, Action> {
@@ -322,7 +322,7 @@ class PrimeTest {
     fun `Prime actions { intercept } receives Action`() {
         val watcher = PublishSubject.create<Action>()
         val observer = watcher.test()
-        val knot = testCompositeKnot<State> {
+        val knot = compositeKnot<State> {
             state { initial = State("empty") }
         }
         knot.registerPrime<Change, Action> {
@@ -344,7 +344,7 @@ class PrimeTest {
     fun `Prime changes { watchAll } receives Change`() {
         val watcher = PublishSubject.create<Change>()
         val observer = watcher.test()
-        val knot = testCompositeKnot<State> {
+        val knot = compositeKnot<State> {
             state { initial = State("empty") }
         }
         knot.registerPrime<Change, Action> {
@@ -364,7 +364,7 @@ class PrimeTest {
     fun `Prime changes { watch } receives Change`() {
         val watcher = PublishSubject.create<Change>()
         val observer = watcher.test()
-        val knot = testCompositeKnot<State> {
+        val knot = compositeKnot<State> {
             state { initial = State("empty") }
         }
         knot.registerPrime<Change, Action> {
@@ -384,7 +384,7 @@ class PrimeTest {
     fun `Prime changes { intercept } receives Change`() {
         val watcher = PublishSubject.create<Change>()
         val observer = watcher.test()
-        val knot = testCompositeKnot<State> {
+        val knot = compositeKnot<State> {
             state { initial = State("empty") }
         }
         knot.registerPrime<Change, Action> {
@@ -403,7 +403,7 @@ class PrimeTest {
     @Test
     fun `CompositeKnot state { watchAll } receives State`() {
         val watcher = PublishSubject.create<State>()
-        val knot = testCompositeKnot<State> {
+        val knot = compositeKnot<State> {
             state {
                 initial = State("empty")
                 watchAll { watcher.onNext(it) }
@@ -428,7 +428,7 @@ class PrimeTest {
     @Test
     fun `CompositeKnot changes { watchAll } receives Change`() {
         val watcher = PublishSubject.create<Any>()
-        val knot = testCompositeKnot<State> {
+        val knot = compositeKnot<State> {
             state {
                 initial = State("empty")
             }
@@ -454,7 +454,7 @@ class PrimeTest {
     @Test
     fun `CompositeKnot actions { watchAll } receives Action`() {
         val watcher = PublishSubject.create<Any>()
-        val knot = testCompositeKnot<State> {
+        val knot = compositeKnot<State> {
             state {
                 initial = State("empty")
             }
@@ -480,7 +480,7 @@ class PrimeTest {
     @Test
     fun `CompositeKnot state { watch } receives State`() {
         val watcher = PublishSubject.create<State>()
-        val knot = testCompositeKnot<State> {
+        val knot = compositeKnot<State> {
             state {
                 initial = State("empty")
                 watch<State> { watcher.onNext(it) }
@@ -505,7 +505,7 @@ class PrimeTest {
     @Test
     fun `Prime state { watchAll } receives State`() {
         val watcher = PublishSubject.create<State>()
-        val knot = testCompositeKnot<State> {
+        val knot = compositeKnot<State> {
             state {
                 initial = State("empty")
             }
@@ -532,7 +532,7 @@ class PrimeTest {
     @Test
     fun `Prime state { watch } receives State`() {
         val watcher = PublishSubject.create<State>()
-        val knot = testCompositeKnot<State> {
+        val knot = compositeKnot<State> {
             state {
                 initial = State("empty")
             }
@@ -559,7 +559,7 @@ class PrimeTest {
     @Test
     fun `Prime receives updates when listens to state updates inside events { } section`() {
 
-        val knot = testCompositeKnot<State> {
+        val knot = compositeKnot<State> {
             state {
                 initial = State("empty")
             }


### PR DESCRIPTION
* Merge `TestCompositeKnot` into `CompositeKnot` (use `CompositeKnot` in tests too)
* Ensure state interceptors get called before `distinctUntilChanged`