### PR TITLE
Allow state + null and effect + null

### DIFF
--- a/knot/src/main/kotlin/de/halfbit/knot/CompositeKnotBuilder.kt
+++ b/knot/src/main/kotlin/de/halfbit/knot/CompositeKnotBuilder.kt
@@ -203,10 +203,10 @@ internal constructor(
         val State.only: Effect<State, Action> get() = Effect.WithAction(this)
 
         /** Combines [State] and [Action] into [Effect]. */
-        operator fun State.plus(action: Action) = Effect.WithAction(this, action)
+        operator fun State.plus(action: Action?) = Effect.WithAction(this, action)
 
         /** Adds another action to [Effect]. */
-        operator fun Effect<State, Action>.plus(action: Action) = plus(action)
+        operator fun Effect<State, Action>.plus(action: Action?) = if (action == null) this else plus(action)
 
         /** Throws [IllegalStateException] with current [State] and given [Change] in its message. */
         fun State.unexpected(change: Change): Nothing = error("Unexpected $change in $this")

--- a/knot/src/main/kotlin/de/halfbit/knot/CompositeKnotBuilder.kt
+++ b/knot/src/main/kotlin/de/halfbit/knot/CompositeKnotBuilder.kt
@@ -206,7 +206,7 @@ internal constructor(
         operator fun State.plus(action: Action?) = Effect.WithAction(this, action)
 
         /** Adds another action to [Effect]. */
-        operator fun Effect<State, Action>.plus(action: Action?) = if (action == null) this else plus(action)
+        operator fun Effect<State, Action>.plus(action: Action?) = plus(action)
 
         /** Throws [IllegalStateException] with current [State] and given [Change] in its message. */
         fun State.unexpected(change: Change): Nothing = error("Unexpected $change in $this")

--- a/knot/src/main/kotlin/de/halfbit/knot/CompositeKnotBuilder.kt
+++ b/knot/src/main/kotlin/de/halfbit/knot/CompositeKnotBuilder.kt
@@ -205,9 +205,6 @@ internal constructor(
         /** Combines [State] and [Action] into [Effect]. */
         operator fun State.plus(action: Action?) = Effect.WithAction(this, action)
 
-        /** Adds another action to [Effect]. */
-        operator fun Effect<State, Action>.plus(action: Action?) = plus(action)
-
         /** Throws [IllegalStateException] with current [State] and given [Change] in its message. */
         fun State.unexpected(change: Change): Nothing = error("Unexpected $change in $this")
     }

--- a/knot/src/main/kotlin/de/halfbit/knot/Knot.kt
+++ b/knot/src/main/kotlin/de/halfbit/knot/Knot.kt
@@ -87,23 +87,27 @@ interface Store<State : Any> {
 
 /** Convenience wrapper around [State] and optional [Action]. */
 sealed class Effect<State : Any, Action : Any> {
-    abstract fun plus(action: Action): Effect<State, Action>
+    abstract fun plus(action: Action?): Effect<State, Action>
 
     data class WithAction<State : Any, Action : Any>(
         val state: State,
         val action: Action? = null
     ) : Effect<State, Action>() {
-        override fun plus(action: Action): Effect<State, Action> =
-            if (this.action == null) WithAction(state, action)
-            else WithActions(state, listOf(this.action, action))
+        override fun plus(action: Action?): Effect<State, Action> =
+            when {
+                action == null -> this
+                this.action == null -> WithAction(state, action)
+                else -> WithActions(state, listOf(this.action, action))
+            }
     }
 
     data class WithActions<State : Any, Action : Any>(
         val state: State,
         val actions: List<Action>
     ) : Effect<State, Action>() {
-        override fun plus(action: Action): Effect<State, Action> =
-            WithActions(state, actions + action)
+        override fun plus(action: Action?): Effect<State, Action> =
+            if (action == null) this
+            else WithActions(state, actions + action)
     }
 }
 

--- a/knot/src/main/kotlin/de/halfbit/knot/Knot.kt
+++ b/knot/src/main/kotlin/de/halfbit/knot/Knot.kt
@@ -87,7 +87,9 @@ interface Store<State : Any> {
 
 /** Convenience wrapper around [State] and optional [Action]. */
 sealed class Effect<State : Any, Action : Any> {
-    abstract fun plus(action: Action?): Effect<State, Action>
+
+    /** Adds another action to [Effect]. */
+    abstract operator fun plus(action: Action?): Effect<State, Action>
 
     data class WithAction<State : Any, Action : Any>(
         val state: State,

--- a/knot/src/main/kotlin/de/halfbit/knot/KnotBuilder.kt
+++ b/knot/src/main/kotlin/de/halfbit/knot/KnotBuilder.kt
@@ -127,7 +127,7 @@ internal constructor() {
         operator fun State.plus(action: Action?) = Effect.WithAction(this, action)
 
         /** Adds another action to [Effect]. */
-        operator fun Effect<State, Action>.plus(action: Action?) = if (action == null) this else plus(action)
+        operator fun Effect<State, Action>.plus(action: Action?) = plus(action)
 
         /** Throws [IllegalStateException] with current [State] and given [Change] in its message. */
         fun State.unexpected(change: Change): Nothing = error("Unexpected $change in $this")

--- a/knot/src/main/kotlin/de/halfbit/knot/KnotBuilder.kt
+++ b/knot/src/main/kotlin/de/halfbit/knot/KnotBuilder.kt
@@ -124,10 +124,10 @@ internal constructor() {
         val State.only: Effect<State, Action> get() = Effect.WithAction(this)
 
         /** Combines [State] and [Action] into [Effect]. */
-        operator fun State.plus(action: Action) = Effect.WithAction(this, action)
+        operator fun State.plus(action: Action?) = Effect.WithAction(this, action)
 
         /** Adds another action to [Effect]. */
-        operator fun Effect<State, Action>.plus(action: Action) = plus(action)
+        operator fun Effect<State, Action>.plus(action: Action?) = if (action == null) this else plus(action)
 
         /** Throws [IllegalStateException] with current [State] and given [Change] in its message. */
         fun State.unexpected(change: Change): Nothing = error("Unexpected $change in $this")

--- a/knot/src/main/kotlin/de/halfbit/knot/KnotBuilder.kt
+++ b/knot/src/main/kotlin/de/halfbit/knot/KnotBuilder.kt
@@ -126,9 +126,6 @@ internal constructor() {
         /** Combines [State] and [Action] into [Effect]. */
         operator fun State.plus(action: Action?) = Effect.WithAction(this, action)
 
-        /** Adds another action to [Effect]. */
-        operator fun Effect<State, Action>.plus(action: Action?) = plus(action)
-
         /** Throws [IllegalStateException] with current [State] and given [Change] in its message. */
         fun State.unexpected(change: Change): Nothing = error("Unexpected $change in $this")
     }

--- a/knot/src/test/kotlin/de/halfbit/knot/KnotEffectTest.kt
+++ b/knot/src/test/kotlin/de/halfbit/knot/KnotEffectTest.kt
@@ -90,6 +90,25 @@ class KnotEffectTest {
     }
 
     @Test
+    fun `Knot Effect this + one action + null`() {
+        val actions = PublishSubject.create<Action>()
+        val knot = knot<State, Change, Action> {
+            state {
+                initial = State
+            }
+            changes {
+                reduce { this + Action.One + null }
+            }
+            actions {
+                watchAll { actions.onNext(it) }
+            }
+        }
+        val observer = actions.test()
+        knot.change.accept(Change)
+        observer.assertValues(Action.One)
+    }
+
+    @Test
     fun `Knot Effect only + one action`() {
         val actions = PublishSubject.create<Action>()
         val knot = knot<State, Change, Action> {
@@ -117,6 +136,27 @@ class KnotEffectTest {
             }
             changes {
                 reduce { this + Action.One + Action.Two }
+            }
+            actions {
+                watchAll { actions.onNext(it) }
+            }
+        }
+        val observer = actions.test()
+        knot.change.accept(Change)
+        observer.assertValues(
+            Action.One, Action.Two
+        )
+    }
+
+    @Test
+    fun `Knot Effect this + two actions + null`() {
+        val actions = PublishSubject.create<Action>()
+        val knot = knot<State, Change, Action> {
+            state {
+                initial = State
+            }
+            changes {
+                reduce { this + Action.One + Action.Two + null }
             }
             actions {
                 watchAll { actions.onNext(it) }

--- a/knot/src/test/kotlin/de/halfbit/knot/KnotEffectTest.kt
+++ b/knot/src/test/kotlin/de/halfbit/knot/KnotEffectTest.kt
@@ -362,7 +362,7 @@ class KnotEffectTest {
         }
         compositeKnot.registerPrime<Change, Action> {
             changes {
-                reduce<Change> { this + Action.One + Action.Two }
+                reduce<Change> { this + Action.One + Action.Two + null }
             }
             actions {
                 watchAll { actions.onNext(it) }

--- a/knot/src/test/kotlin/de/halfbit/knot/KnotEffectTest.kt
+++ b/knot/src/test/kotlin/de/halfbit/knot/KnotEffectTest.kt
@@ -33,6 +33,44 @@ class KnotEffectTest {
     }
 
     @Test
+    fun `Knot Effect + null action`() {
+        val actions = PublishSubject.create<Action>()
+        val knot = knot<State, Change, Action> {
+            state {
+                initial = State
+            }
+            changes {
+                reduce { only + null  }
+            }
+            actions {
+                watchAll { actions.onNext(it) }
+            }
+        }
+        val observer = actions.test()
+        knot.change.accept(Change)
+        observer.assertEmpty()
+    }
+
+    @Test
+    fun `Knot Effect this + null action`() {
+        val actions = PublishSubject.create<Action>()
+        val knot = knot<State, Change, Action> {
+            state {
+                initial = State
+            }
+            changes {
+                reduce { this + null }
+            }
+            actions {
+                watchAll { actions.onNext(it) }
+            }
+        }
+        val observer = actions.test()
+        knot.change.accept(Change)
+        observer.assertEmpty()
+    }
+
+    @Test
     fun `Knot Effect this + one action`() {
         val actions = PublishSubject.create<Action>()
         val knot = knot<State, Change, Action> {
@@ -123,6 +161,50 @@ class KnotEffectTest {
         compositeKnot.registerPrime<Change, Action> {
             changes {
                 reduce<Change> { only }
+            }
+            actions {
+                watchAll { actions.onNext(it) }
+            }
+        }
+        compositeKnot.compose()
+        val observer = actions.test()
+        compositeKnot.change.accept(Change)
+        observer.assertEmpty()
+    }
+
+    @Test
+    fun `CompositeKnot Effect + null action`() {
+        val actions = PublishSubject.create<Action>()
+        val compositeKnot = compositeKnot<State> {
+            state {
+                initial = State
+            }
+        }
+        compositeKnot.registerPrime<Change, Action> {
+            changes {
+                reduce<Change> { only + null }
+            }
+            actions {
+                watchAll { actions.onNext(it) }
+            }
+        }
+        compositeKnot.compose()
+        val observer = actions.test()
+        compositeKnot.change.accept(Change)
+        observer.assertEmpty()
+    }
+
+    @Test
+    fun `CompositeKnot Effect this + null action`() {
+        val actions = PublishSubject.create<Action>()
+        val compositeKnot = compositeKnot<State> {
+            state {
+                initial = State
+            }
+        }
+        compositeKnot.registerPrime<Change, Action> {
+            changes {
+                reduce<Change> { this + null }
             }
             actions {
                 watchAll { actions.onNext(it) }

--- a/knot/src/test/kotlin/de/halfbit/knot/KnotEffectTest.kt
+++ b/knot/src/test/kotlin/de/halfbit/knot/KnotEffectTest.kt
@@ -281,6 +281,30 @@ class KnotEffectTest {
     }
 
     @Test
+    fun `CompositeKnot Effect this + one action + null`() {
+        val actions = PublishSubject.create<Action>()
+        val compositeKnot = compositeKnot<State> {
+            state {
+                initial = State
+            }
+        }
+        compositeKnot.registerPrime<Change, Action> {
+            changes {
+                reduce<Change> { this + Action.One + null }
+            }
+            actions {
+                watchAll { actions.onNext(it) }
+            }
+        }
+        compositeKnot.compose()
+        val observer = actions.test()
+        compositeKnot.change.accept(Change)
+        observer.assertValues(
+            Action.One
+        )
+    }
+
+    @Test
     fun `CompositeKnot Effect only + one action`() {
         val actions = PublishSubject.create<Action>()
         val compositeKnot = compositeKnot<State> {
@@ -306,6 +330,30 @@ class KnotEffectTest {
 
     @Test
     fun `CompositeKnot Effect only + two actions`() {
+        val actions = PublishSubject.create<Action>()
+        val compositeKnot = compositeKnot<State> {
+            state {
+                initial = State
+            }
+        }
+        compositeKnot.registerPrime<Change, Action> {
+            changes {
+                reduce<Change> { this + Action.One + Action.Two }
+            }
+            actions {
+                watchAll { actions.onNext(it) }
+            }
+        }
+        compositeKnot.compose()
+        val observer = actions.test()
+        compositeKnot.change.accept(Change)
+        observer.assertValues(
+            Action.One, Action.Two
+        )
+    }
+
+    @Test
+    fun `CompositeKnot Effect only + two actions + null`() {
         val actions = PublishSubject.create<Action>()
         val compositeKnot = compositeKnot<State> {
             state {


### PR DESCRIPTION
I've recently struggled a bit with having clean conditional effects in my reducer.

In a reduce step where the incoming Change and current state may or may not result in an action, the `+` operator doesn't cut it anymore.

The operator is REALLY nice, and I want to keep using it even for cases like this
```kotlin
val action = if (this.isReadyForAction) Action.DoAwesomeStuff else null
this + action // Instead of Effect.WithAction(this, action)
```

... and potentially with lists too:
```kotlin
this + listOf(ActionOne, ActionTwo, ActionThree)
```

Thoughts? :)