### PR TITLE
Change behavior of interceptors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 allprojects {
     group = "de.halfbit"
-    version = "1.4"
+    version = "1.5-alpha1"
 
     repositories {
         mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 allprojects {
     group = "de.halfbit"
-    version = "1.5-alpha1"
+    version = "1.5-alpha2"
 
     repositories {
         mavenCentral()

--- a/buildSrc/src/main/kotlin/Deps.kt
+++ b/buildSrc/src/main/kotlin/Deps.kt
@@ -1,7 +1,7 @@
 object Deps {
 
     object Version {
-        const val kotlin = "1.3.31"
+        const val kotlin = "1.3.41"
         const val dokka = "0.9.17"
         const val jvmTarget = "1.6"
     }

--- a/knot/src/main/kotlin/de/halfbit/knot/CompositeKnot.kt
+++ b/knot/src/main/kotlin/de/halfbit/knot/CompositeKnot.kt
@@ -92,7 +92,7 @@ internal class DefaultCompositeKnot<State : Any>(
                     val reducer = reducers[change::class] ?: error("Cannot find reducer for $change")
                     reducer(state, change).emitActions(actionSubject)
                 }
-                .distinctUntilChanged()
+                .distinctUntilChanged { prev, curr -> prev === curr }
                 .let { stream -> observeOn?.let { stream.observeOn(it) } ?: stream }
                 .intercept(stateInterceptors)
                 .subscribe(

--- a/knot/src/main/kotlin/de/halfbit/knot/CompositeKnot.kt
+++ b/knot/src/main/kotlin/de/halfbit/knot/CompositeKnot.kt
@@ -86,15 +86,15 @@ internal class DefaultCompositeKnot<State : Any>(
                     }
                 )
                 .let { stream -> reduceOn?.let { stream.observeOn(it) } ?: stream }
-                .intercept(changeInterceptors)
                 .serialize()
+                .intercept(changeInterceptors)
                 .scan(initialState) { state, change ->
                     val reducer = reducers[change::class] ?: error("Cannot find reducer for $change")
                     reducer(state, change).emitActions(actionSubject)
                 }
-                .intercept(stateInterceptors)
                 .distinctUntilChanged()
                 .let { stream -> observeOn?.let { stream.observeOn(it) } ?: stream }
+                .intercept(stateInterceptors)
                 .subscribe(
                     { stateSubject.onNext(it) },
                     { stateSubject.onError(it) }

--- a/knot/src/main/kotlin/de/halfbit/knot/Knot.kt
+++ b/knot/src/main/kotlin/de/halfbit/knot/Knot.kt
@@ -162,7 +162,7 @@ internal class DefaultKnot<State : Any, Change : Any, Action : Any>(
         .serialize()
         .intercept(changeInterceptors)
         .scan(initialState) { state, change -> reducer(state, change).emitActions(actionSubject) }
-        .distinctUntilChanged()
+        .distinctUntilChanged { prev, curr -> prev === curr }
         .intercept(stateInterceptors)
         .let { stream -> observeOn?.let { stream.observeOn(it) } ?: stream }
         .replay(1)

--- a/knot/src/main/kotlin/de/halfbit/knot/Knot.kt
+++ b/knot/src/main/kotlin/de/halfbit/knot/Knot.kt
@@ -159,11 +159,11 @@ internal class DefaultKnot<State : Any, Change : Any, Action : Any>(
             }
         )
         .let { stream -> reduceOn?.let { stream.observeOn(it) } ?: stream }
-        .intercept(changeInterceptors)
         .serialize()
+        .intercept(changeInterceptors)
         .scan(initialState) { state, change -> reducer(state, change).emitActions(actionSubject) }
-        .intercept(stateInterceptors)
         .distinctUntilChanged()
+        .intercept(stateInterceptors)
         .let { stream -> observeOn?.let { stream.observeOn(it) } ?: stream }
         .replay(1)
         .also { disposable.add(it.connect()) }

--- a/knot/src/test/kotlin/de/halfbit/knot/KnotInterceptStateTest.kt
+++ b/knot/src/test/kotlin/de/halfbit/knot/KnotInterceptStateTest.kt
@@ -131,4 +131,30 @@ class KnotInterceptStateTest {
             State.One
         )
     }
+
+    @Test
+    fun `state { intercept } intercepts after distinctUntilChanged`() {
+        val interceptor = PublishSubject.create<State>()
+        val observer = interceptor.test()
+        val knot = knot<State, Change, Action> {
+            state {
+                initial = State.Zero
+                intercept { state -> state.doOnNext { interceptor.onNext(it) } }
+            }
+            changes {
+                reduce { change ->
+                    when (change) {
+                        Change.One -> State.One.only
+                    }
+                }
+            }
+        }
+        knot.change.accept(Change.One)
+        knot.change.accept(Change.One)
+        knot.change.accept(Change.One)
+        observer.assertValues(
+            State.Zero,
+            State.One
+        )
+    }
 }


### PR DESCRIPTION
This changes changes behavior of interceptors as following:

* Change interceptor gets called *after* `serialize()` to avoid possible race conditions.
* State interceptor gets called *after* `distinctUntilChanged()` to avoid interception of not dispatched state.

@gustavkarlsson What do you think?