### PR TITLE
Adding TypedInterceptor to being used in Primes

### DIFF
--- a/knot/src/test/kotlin/de/halfbit/knot/PrimeInterceptChangeTest.kt
+++ b/knot/src/test/kotlin/de/halfbit/knot/PrimeInterceptChangeTest.kt
@@ -20,12 +20,16 @@ class PrimeInterceptChangeTest {
         knot.registerPrime<ChangeA, Action> {
             changes {
                 reduce<ChangeA> { this + Action }
-                intercept<ChangeA> { change -> change.doOnNext { watcher.onNext(it) } }
+                intercept<ChangeA> { change ->
+                    change.doOnNext {
+                        watcher.onNext(it.copy(value = "${it.value} intercepted"))
+                    }
+                }
             }
         }
         knot.compose()
-        knot.change.accept(ChangeA("changed"))
-        observer.assertValues(ChangeA("changed"))
+        knot.change.accept(ChangeA("change a"))
+        observer.assertValues(ChangeA("change a intercepted"))
     }
 
     @Test
@@ -42,7 +46,9 @@ class PrimeInterceptChangeTest {
                 reduce<ChangeA> { only }
                 intercept<ChangeA> { change ->
                     change.doOnNext {
-                        watcher.onNext(it)
+                        if (it.value == "change a") {
+                            watcher.onNext(it.copy(value = "${it.value} intercepted"))
+                        }
                     }
                 }
             }
@@ -53,18 +59,20 @@ class PrimeInterceptChangeTest {
                 reduce<ChangeB> { only }
                 intercept<ChangeB> { change ->
                     change.doOnNext {
-                        watcher.onNext(it)
+                        if (it.value == "change b") {
+                            watcher.onNext(it.copy(value = "${it.value} intercepted"))
+                        }
                     }
                 }
             }
         }
 
         knot.compose()
-        knot.change.accept(ChangeA("changed"))
-        knot.change.accept(ChangeB("changed"))
+        knot.change.accept(ChangeA("change a"))
+        knot.change.accept(ChangeB("change b"))
         observer.assertValues(
-            ChangeA("changed"),
-            ChangeB("changed")
+            ChangeA("change a intercepted"),
+            ChangeB("change b intercepted")
         )
     }
 }

--- a/knot/src/test/kotlin/de/halfbit/knot/PrimeInterceptChangeTest.kt
+++ b/knot/src/test/kotlin/de/halfbit/knot/PrimeInterceptChangeTest.kt
@@ -1,0 +1,70 @@
+package de.halfbit.knot
+
+import io.reactivex.subjects.PublishSubject
+import org.junit.Test
+
+class PrimeInterceptChangeTest {
+
+    private data class State(val value: String)
+    private data class ChangeA(val value: String)
+    private data class ChangeB(val value: String)
+    private object Action
+
+    @Test
+    fun `Prime (single) changes { intercept } receives Change`() {
+        val watcher = PublishSubject.create<ChangeA>()
+        val observer = watcher.test()
+        val knot = compositeKnot<State> {
+            state { initial = State("empty") }
+        }
+        knot.registerPrime<ChangeA, Action> {
+            changes {
+                reduce<ChangeA> { this + Action }
+                intercept<ChangeA> { change -> change.doOnNext { watcher.onNext(it) } }
+            }
+        }
+        knot.compose()
+        knot.change.accept(ChangeA("changed"))
+        observer.assertValues(ChangeA("changed"))
+    }
+
+    @Test
+    fun `Prime (many) changes { intercept } receives Change`() {
+        val watcher = PublishSubject.create<Any>()
+        val observer = watcher.test()
+
+        val knot = compositeKnot<State> {
+            state { initial = State("empty") }
+        }
+
+        knot.registerPrime<ChangeA, Action> {
+            changes {
+                reduce<ChangeA> { only }
+                intercept<ChangeA> { change ->
+                    change.doOnNext {
+                        watcher.onNext(it)
+                    }
+                }
+            }
+        }
+
+        knot.registerPrime<ChangeB, Action> {
+            changes {
+                reduce<ChangeB> { only }
+                intercept<ChangeB> { change ->
+                    change.doOnNext {
+                        watcher.onNext(it)
+                    }
+                }
+            }
+        }
+
+        knot.compose()
+        knot.change.accept(ChangeA("changed"))
+        knot.change.accept(ChangeB("changed"))
+        observer.assertValues(
+            ChangeA("changed"),
+            ChangeB("changed")
+        )
+    }
+}

--- a/knot/src/test/kotlin/de/halfbit/knot/PrimeTest.kt
+++ b/knot/src/test/kotlin/de/halfbit/knot/PrimeTest.kt
@@ -558,26 +558,6 @@ class PrimeTest {
     }
 
     @Test
-    fun `Prime changes { intercept } receives Change`() {
-        val watcher = PublishSubject.create<Change>()
-        val observer = watcher.test()
-        val knot = compositeKnot<State> {
-            state { initial = State("empty") }
-        }
-        knot.registerPrime<Change, Action> {
-            changes {
-                reduce<Change.A> { this + Action.A }
-                intercept { change -> change.doOnNext { watcher.onNext(it) } }
-            }
-        }
-        knot.compose()
-        knot.change.accept(Change.A)
-        observer.assertValues(
-            Change.A
-        )
-    }
-
-    @Test
     fun `Prime state { intercept } intercepts after distinctUntilChanged`() {
         val interceptor = PublishSubject.create<State>()
         val observer = interceptor.test()


### PR DESCRIPTION
Fixes #18 

This fix introduces an incompatible change to the Prime DSL - interceptors must declare reified type now (see [de/halfbit/knot/PrimeInterceptChangeTest.kt](https://github.com/beworker/knot/blob/7b450762e40d7ebae25f4935ae21a06ef239c350/knot/src/test/kotlin/de/halfbit/knot/PrimeInterceptChangeTest.kt))

```kotlin
knot.registerPrime<Change, Action> {
    changes {
        intercept<Change> { change ->
            // intercept change here
        }
    }
}
```
