### PR TITLE
State.whenState & State.requireState

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.iml
+*.hprof
 
 .gradle
 .DS_Store

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 allprojects {
     group = "de.halfbit"
-    version = "3.1.1"
+    version = "3.2-alpha1"
 
     repositories {
         mavenCentral()

--- a/knot3/src/main/kotlin/de/halfbit/knot3/CompositeKnotBuilder.kt
+++ b/knot3/src/main/kotlin/de/halfbit/knot3/CompositeKnotBuilder.kt
@@ -241,6 +241,12 @@ internal constructor(
         ): Effect<State, Action> =
             if (this is WhenState) block()
             else Effect.WithAction(this, null)
+
+        inline fun <reified WhenState : State> State.requireState(
+            change: Change, block: WhenState.() -> Effect<State, Action>
+        ): Effect<State, Action> =
+            if (this is WhenState) block()
+            else unexpected(change)
     }
 }
 

--- a/knot3/src/main/kotlin/de/halfbit/knot3/CompositeKnotBuilder.kt
+++ b/knot3/src/main/kotlin/de/halfbit/knot3/CompositeKnotBuilder.kt
@@ -234,6 +234,13 @@ internal constructor(
 
         /** Throws [IllegalStateException] with current [State] and given [Change] in its message. */
         fun State.unexpected(change: Change): Nothing = error("Unexpected $change in $this")
+
+        /** Executes given block if the knot is in the given state and ignores all the other changes. **/
+        inline fun <reified WhenState : State> State.whenState(
+            block: WhenState.() -> Effect<State, Action>
+        ): Effect<State, Action> =
+            if (this is WhenState) block()
+            else Effect.WithAction(this, null)
     }
 }
 

--- a/knot3/src/test/kotlin/de/halfbit/knot3/CompositeKnotRequireStateTest.kt
+++ b/knot3/src/test/kotlin/de/halfbit/knot3/CompositeKnotRequireStateTest.kt
@@ -4,7 +4,7 @@ import de.halfbit.knot3.utils.RxPluginsException
 import org.junit.Rule
 import org.junit.Test
 
-class CompositeKnotWhenStateTest {
+class CompositeKnotRequireStateTest {
 
     @Rule
     @JvmField
@@ -27,7 +27,7 @@ class CompositeKnotWhenStateTest {
     }
 
     @Test
-    fun `whenState lets known change through`() {
+    fun `requireState lets known change through`() {
         val knot = createKnot(initialState = State.Empty)
         val states = knot.state.test()
         knot.change.accept(Change.Load)
@@ -39,7 +39,9 @@ class CompositeKnotWhenStateTest {
     }
 
     @Test
-    fun `whenState ignores unknown change through`() {
+    fun `requireState throws when unknown change received`() {
+        rxPluginsException.expect(IllegalStateException::class)
+
         val knot = createKnot(initialState = State.Loading)
         val states = knot.state.test()
         knot.change.accept(Change.Load)
@@ -52,8 +54,8 @@ class CompositeKnotWhenStateTest {
         }.apply {
             registerPrime<Change, Action> {
                 changes {
-                    reduce<Change.Load> {
-                        whenState<State.Empty> {
+                    reduce<Change.Load> { change ->
+                        requireState<State.Empty>(change) {
                             State.Loading + Action.Load
                         }
                     }

--- a/knot3/src/test/kotlin/de/halfbit/knot3/CompositeKnotWhenStateTest.kt
+++ b/knot3/src/test/kotlin/de/halfbit/knot3/CompositeKnotWhenStateTest.kt
@@ -1,0 +1,66 @@
+package de.halfbit.knot3
+
+import org.junit.Test
+
+class CompositeKnotWhenStateTest {
+
+    private sealed class State {
+        object Empty : State()
+        object Loading : State()
+        data class Content(val data: String) : State()
+    }
+
+    private sealed class Change {
+        object Load : Change() {
+            data class Success(val data: String) : Change()
+        }
+    }
+
+    private sealed class Action {
+        object Load : Action()
+    }
+
+    @Test
+    fun `whenState lets known change through`() {
+        val knot = createKnot(initialState = State.Empty)
+        val states = knot.state.test()
+        knot.change.accept(Change.Load)
+        states.assertValues(
+            State.Empty,
+            State.Loading,
+            State.Content("ok")
+        )
+    }
+
+    @Test
+    fun `whenState ignores unknown change through`() {
+        val knot = createKnot(initialState = State.Loading)
+        val states = knot.state.test()
+        knot.change.accept(Change.Load)
+        states.assertValues(State.Loading)
+    }
+
+    private fun createKnot(initialState: State): CompositeKnot<State> =
+        compositeKnot<State> {
+            state { initial = initialState }
+        }.apply {
+            registerPrime<Change, Action> {
+                changes {
+                    reduce<Change.Load> {
+                        whenState<State.Empty> {
+                            State.Loading + Action.Load
+                        }
+                    }
+                    reduce<Change.Load.Success> { change ->
+                        State.Content(change.data).only
+                    }
+                }
+                actions {
+                    perform<Action.Load> {
+                        map { Change.Load.Success("ok") }
+                    }
+                }
+            }
+            compose()
+        }
+}

--- a/knot3/src/test/kotlin/de/halfbit/knot3/PrimeTest.kt
+++ b/knot3/src/test/kotlin/de/halfbit/knot3/PrimeTest.kt
@@ -161,7 +161,7 @@ class PrimeTest {
         }
         knot.registerPrime<Change, Action> {
             changes {
-                reduce<Change> { only }
+                reduce<Change.A> { only }
             }
         }
 
@@ -184,7 +184,7 @@ class PrimeTest {
         }
         knot.registerPrime<Change, Action> {
             changes {
-                reduce<Change> { only }
+                reduce<Change.A> { only }
             }
         }
 
@@ -225,7 +225,7 @@ class PrimeTest {
         }
         knot.registerPrime<Change, Action> {
             changes {
-                reduce<Change> { only }
+                reduce<Change.A> { only }
             }
         }
         knot.compose()

--- a/knot3/src/test/kotlin/de/halfbit/knot3/utils/RxPluginsException.kt
+++ b/knot3/src/test/kotlin/de/halfbit/knot3/utils/RxPluginsException.kt
@@ -47,6 +47,9 @@ class RxPluginsException private constructor() : TestRule {
                     val observedType = observedException?.let { it::class }
                     Assert.assertThat(observedType, IsEqual(expectedType))
                 }
+                else -> {
+                    observedException?.let { throw it }
+                }
             }
         }
     }


### PR DESCRIPTION
`State.whenState` and `State.requireState` simplify reducers in delegates as follows.

### State.whenState
```kotlin
reduce<Change.Load> {
    whenState<State.Empty> {
        State.Loading + Action.Load
    }
}
```
is a shortcut for
```kotlin
reduce<Change.Load> {
   when(this) {
       is State.Empty -> State.Loading + Action.Load
       else -> only
   }
}
```

### State.requireState
```kotlin
reduce<Change.Load> {
    requireState<State.Empty>(change) {
        State.Loading + Action.Load
    }
}
```
is a shortcut for
```kotlin
reduce<Change.Load> {
   when(this) { change ->
       is State.Empty -> State.Loading + Action.Load
       else -> unexpected(change)
   }
}
```

